### PR TITLE
ConcurrentModificationException fix in TCPIPConnectionPoolManager

### DIFF
--- a/bindings/transport-tcpip/src/main/java/esa/mo/mal/transport/tcpip/TCPIPConnectionPoolManager.java
+++ b/bindings/transport-tcpip/src/main/java/esa/mo/mal/transport/tcpip/TCPIPConnectionPoolManager.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -140,10 +141,11 @@ public enum TCPIPConnectionPoolManager {
     public synchronized void close() {
         RLOGGER.info("Closing client sockets...");
 
-        for (int hash : connections.keySet()) {
+        Iterator<Map.Entry<Integer, Socket>> iterator = connections.entrySet().iterator();
+        while(iterator.hasNext()) {
             try {
-                connections.get(hash).close();
-                connections.remove(hash);
+                connections.get(iterator.next().getKey()).close();
+                iterator.remove();
             } catch (IOException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();


### PR DESCRIPTION
This pull request fixes a ConcurrentModificationException in TCPIPConnectionPoolManager that could happen if there's more than one entry in the connections map.