### PR TITLE
Fix AttributeList

### DIFF
--- a/testbeds/testbed-mal/src/main/java/org/ccsds/moims/mo/mal/test/datatype/TestData.java
+++ b/testbeds/testbed-mal/src/main/java/org/ccsds/moims/mo/mal/test/datatype/TestData.java
@@ -169,9 +169,12 @@ public abstract class TestData {
         domId.add(testIdentifier);
         domId.add(testIdentifier);
         domId.add(testIdentifier);
+        AttributeList testKeyValues = new AttributeList();
+        testKeyValues.add(new Identifier("TestValue"));
+        testKeyValues.add(new String("TestValue"));
         TestPublish a = new TestPublishRegister(QoSLevel.QUEUED, testUInteger, domId, testIdentifier, testEnumeration, testIdentifier, false, null, testUInteger);
-        TestPublish b = new TestPublishUpdate(QoSLevel.QUEUED, testUInteger, domId, testIdentifier, testEnumeration, testIdentifier, false, null, null, null, testUInteger, testBoolean, (AttributeList) null);
-        TestPublish c = new TestPublishUpdate(QoSLevel.QUEUED, testUInteger, domId, testIdentifier, testEnumeration, testIdentifier, false, null, null, null, testUInteger, testBoolean, (AttributeList) null);
+        TestPublish b = new TestPublishUpdate(QoSLevel.QUEUED, testUInteger, domId, testIdentifier, testEnumeration, testIdentifier, false, null, null, testKeyValues, testUInteger, testBoolean, (AttributeList) null);
+        TestPublish c = new TestPublishUpdate(QoSLevel.QUEUED, testUInteger, domId, testIdentifier, testEnumeration, testIdentifier, false, null, null, testKeyValues, testUInteger, testBoolean, (AttributeList) null);
         testAbstracts.add(a);
         testAbstracts.add(b);
         testAbstracts.add(c);


### PR DESCRIPTION
Changed AttributeList encode and decode methods to use createListEncoder and createListDecoder instead.
Also, attribute2JavaType was missing. This causes equality check to fail after encoding and then decoding, because Java types are turned into MAL Union type during encode, but not back to Java types during decoding. Modified testbed test data, so that the encode and decode methods actually get called.
The testbed for MAL passes with the change.