### PR TITLE
Release 14.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ ESA CCSDS MO services - Release Notes
 These Release Notes include a short summary of the updates done for each version.
 The different versions and respective updates are the following:
 
-### Version 14.0
+### Version 14.0 (04 July 2026)
 * Removes the setters from the auto-generated classes
 * Removes deprecated methods
 * Adds the partial Monitor & Control service implementations (Action, Alert, and Packet) and respective testbed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,13 @@ ESA CCSDS MO services - Release Notes
 These Release Notes include a short summary of the updates done for each version.
 The different versions and respective updates are the following:
 
+### Version 14.1 (18 July 2026)
+* Vendors the W3C XML Schema files instead of downloading them at build time (removes the build's dependency on network access to w3.org)
+* Fixes a race condition and silent failures in the LazyMessageBody decoding
+* Restores the log-and-continue handling of NotFoundException during decoding
+* No longer reports empty message bodies as failed decodes
+* Loads the consumer.properties file only once per JVM
+
 ### Version 14.0 (04 July 2026)
 * Removes the setters from the auto-generated classes
 * Removes deprecated methods

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,6 +76,8 @@ git pull
 git checkout -b vAA.B
 ```
 
+8. Bump the versions of ALL the pom files to the next development version (example, from: 14.0 to: 14.1-SNAPSHOT), then commit and push. Make sure every pom is updated, including any modules that are detached from the main reactor (e.g. the testbeds), which a single reactor-wide command may miss.
+
 Extra
 -------------
 Complete Maven Central publishing guide available [here][sonatype_guide]!

--- a/api-generator/api-generator-maven-plugin/pom.xml
+++ b/api-generator/api-generator-maven-plugin/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>api-generator-maven-plugin</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>maven-plugin</packaging>
   
     <name>ESA MO API Generator - Maven Plugin</name>

--- a/api-generator/api-generator-maven-plugin/pom.xml
+++ b/api-generator/api-generator-maven-plugin/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>api-generator-maven-plugin</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
   
     <name>ESA MO API Generator - Maven Plugin</name>

--- a/api-generator/generator-docs/pom.xml
+++ b/api-generator/generator-docs/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>generator-docs</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
   
     <name>ESA MO API Generator - Documentation</name>

--- a/api-generator/generator-docs/pom.xml
+++ b/api-generator/generator-docs/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>generator-docs</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
   
     <name>ESA MO API Generator - Documentation</name>

--- a/api-generator/generator-interfaces/pom.xml
+++ b/api-generator/generator-interfaces/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>generator-interfaces</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
   
     <name>ESA MO API Generator - Interfaces</name>
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>int.esa.ccsds.mo</groupId>
             <artifactId>xml-ccsds-mo-prototypes</artifactId>
-            <version>14.0</version>
+            <version>14.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>int.esa.ccsds.mo</groupId>
             <artifactId>xml-ccsds-mo-standards</artifactId>
-            <version>14.0</version>
+            <version>14.1-SNAPSHOT</version>
         </dependency>
         <!-- The dependencies below are needed for Java 9 and higher -->
         <dependency>

--- a/api-generator/generator-interfaces/pom.xml
+++ b/api-generator/generator-interfaces/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>generator-interfaces</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
   
     <name>ESA MO API Generator - Interfaces</name>
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>int.esa.ccsds.mo</groupId>
             <artifactId>xml-ccsds-mo-prototypes</artifactId>
-            <version>14.1-SNAPSHOT</version>
+            <version>14.1</version>
         </dependency>
         <dependency>
             <groupId>int.esa.ccsds.mo</groupId>
             <artifactId>xml-ccsds-mo-standards</artifactId>
-            <version>14.1-SNAPSHOT</version>
+            <version>14.1</version>
         </dependency>
         <!-- The dependencies below are needed for Java 9 and higher -->
         <dependency>

--- a/api-generator/generator-interfaces/pom.xml
+++ b/api-generator/generator-interfaces/pom.xml
@@ -133,7 +133,7 @@
                             <packageName>w3c.xsd</packageName>
                             <laxSchemaValidation>true</laxSchemaValidation>
                             <sources>
-                                <source>${project.build.directory}/xsd-ref/XMLSchema.xsd</source>
+                                <source>${basedir}/src/main/xsd-ref/XMLSchema.xsd</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -153,49 +153,6 @@
                             <sources>
                                 <source>target/generated-sources/stub</source>
                             </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>wagon-maven-plugin</artifactId>
-                <version>2.0.2</version>
-                <executions>
-                    <execution>
-                        <id>get-xsd</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>http://www.w3.org/2009/XMLSchema</url>
-                            <fromFile>XMLSchema.xsd</fromFile>
-                            <toDir>${project.build.directory}/xsd-ref</toDir>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>get-dtd</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>http://www.w3.org/2009/XMLSchema</url>
-                            <fromFile>XMLSchema.dtd</fromFile>
-                            <toDir>${project.build.directory}/xsd-ref</toDir>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>get-dtd-types</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>http://www.w3.org/2009/XMLSchema</url>
-                            <fromFile>datatypes.dtd</fromFile>
-                            <toDir>${project.build.directory}/xsd-ref</toDir>
                         </configuration>
                     </execution>
                 </executions>

--- a/api-generator/generator-interfaces/src/main/xsd-ref/XMLSchema.dtd
+++ b/api-generator/generator-interfaces/src/main/xsd-ref/XMLSchema.dtd
@@ -1,0 +1,513 @@
+<!-- DTD for XML Schema Definition Language Part 1: Structures
+     Public Identifier: "-//W3C//DTD XSD 1.1//EN"
+     Official Location: http://www.w3.org/2009/XMLSchema/XMLSchema.dtd -->
+<!-- Id: structures.dtd,v 1.1 2003/08/28 13:30:52 ht Exp  -->
+<!-- With the exception of cases with multiple namespace
+     prefixes for the XSD namespace, any XML document which is
+     not valid per this DTD given redefinitions in its internal subset of the
+     'p' and 's' parameter entities below appropriate to its namespace
+     declaration of the XSD namespace is almost certainly not
+     a valid schema document. -->
+
+<!-- See below (at the bottom of this document) for information about
+      the revision and namespace-versioning policy governing this DTD. -->
+<!-- The simpleType element and its constituent parts
+     are defined in XML Schema Definition Language Part 2: Datatypes -->
+<!ENTITY % xs-datatypes PUBLIC '-//W3C//DTD XSD 1.1 Datatypes//EN' 'datatypes.dtd' >
+
+<!ENTITY % p 'xs:'> <!-- can be overridden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+<!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+<!ENTITY % nds 'xmlns%s;'>
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % schema "%p;schema">
+<!ENTITY % defaultOpenContent "%p;defaultOpenContent">
+<!ENTITY % complexType "%p;complexType">
+<!ENTITY % complexContent "%p;complexContent">
+<!ENTITY % openContent "%p;openContent">
+<!ENTITY % simpleContent "%p;simpleContent">
+<!ENTITY % extension "%p;extension">
+<!ENTITY % element "%p;element">
+<!ENTITY % alternative "%p;alternative">
+<!ENTITY % unique "%p;unique">
+<!ENTITY % key "%p;key">
+<!ENTITY % keyref "%p;keyref">
+<!ENTITY % selector "%p;selector">
+<!ENTITY % field "%p;field">
+<!ENTITY % group "%p;group">
+<!ENTITY % all "%p;all">
+<!ENTITY % choice "%p;choice">
+<!ENTITY % sequence "%p;sequence">
+<!ENTITY % any "%p;any">
+<!ENTITY % anyAttribute "%p;anyAttribute">
+<!ENTITY % attribute "%p;attribute">
+<!ENTITY % attributeGroup "%p;attributeGroup">
+<!ENTITY % include "%p;include">
+<!ENTITY % import "%p;import">
+<!ENTITY % redefine "%p;redefine">
+<!ENTITY % override "%p;override">
+<!ENTITY % notation "%p;notation">
+<!ENTITY % assert   "%p;assert">
+
+
+<!-- annotation elements -->
+<!ENTITY % annotation "%p;annotation">
+<!ENTITY % appinfo "%p;appinfo">
+<!ENTITY % documentation "%p;documentation">
+
+<!-- Customisation entities for the ATTLIST of each element type.
+     Define one of these if your schema takes advantage of the
+     anyAttribute='##other' in the
+     schema for schema documents -->
+
+<!ENTITY % schemaAttrs ''>
+<!ENTITY % defaultOpenContentAttrs ''>
+<!ENTITY % complexTypeAttrs ''>
+<!ENTITY % complexContentAttrs ''>
+<!ENTITY % openContentAttrs ''>
+<!ENTITY % simpleContentAttrs ''>
+<!ENTITY % extensionAttrs ''>
+<!ENTITY % elementAttrs ''>
+<!ENTITY % groupAttrs ''>
+<!ENTITY % allAttrs ''>
+<!ENTITY % choiceAttrs ''>
+<!ENTITY % sequenceAttrs ''>
+<!ENTITY % anyAttrs ''>
+<!ENTITY % anyAttributeAttrs ''>
+<!ENTITY % attributeAttrs ''>
+<!ENTITY % attributeGroupAttrs ''>
+<!ENTITY % uniqueAttrs ''>
+<!ENTITY % keyAttrs ''>
+<!ENTITY % keyrefAttrs ''>
+<!ENTITY % selectorAttrs ''>
+<!ENTITY % fieldAttrs ''>
+<!ENTITY % assertAttrs ''>
+
+<!ENTITY % includeAttrs ''>
+<!ENTITY % importAttrs ''>
+<!ENTITY % redefineAttrs ''>
+<!ENTITY % overrideAttrs ''>
+<!ENTITY % notationAttrs ''>
+<!ENTITY % annotationAttrs ''>
+<!ENTITY % appinfoAttrs ''>
+<!ENTITY % documentationAttrs ''>
+
+<!ENTITY % complexDerivationSet "CDATA">
+      <!-- #all or space-separated list drawn from derivationChoice -->
+<!ENTITY % blockSet "CDATA">
+      <!-- #all or space-separated list drawn from
+                      derivationChoice + 'substitution' -->
+
+<!ENTITY % composition '%include; | %import; | %override; | %redefine;'>
+<!ENTITY % mgs '%all; | %choice; | %sequence;'>
+<!ENTITY % cs '%choice; | %sequence;'>
+<!ENTITY % formValues '(qualified|unqualified)'>
+
+
+<!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+<!ENTITY % assertions   '(%assert;)*'>
+
+<!ENTITY % particleAndAttrs '(%openContent;?, (%mgs; | %group;)?,
+                              %attrDecls;, %assertions;)'>
+
+<!-- This is used in part2 -->
+<!ENTITY % restriction1 '(%openContent;?, (%mgs; | %group;)?)'>
+
+%xs-datatypes;
+
+<!-- the duplication below is to produce an unambiguous content model
+     which allows annotation everywhere -->
+<!ELEMENT %schema; ((%composition; | %annotation;)*,
+                    (%defaultOpenContent;, (%annotation;)*)?,
+                    ((%simpleType; | %complexType;
+                      | %element; | %attribute;
+                      | %attributeGroup; | %group;
+                      | %notation; ),
+                     (%annotation;)*)* )>
+<!ATTLIST %schema;
+   targetNamespace      %URIref;               #IMPLIED
+   version              CDATA                  #IMPLIED
+   %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+   xmlns                CDATA                  #IMPLIED
+   finalDefault         %complexDerivationSet; ''
+   blockDefault         %blockSet;             ''
+   id                   ID                     #IMPLIED
+   elementFormDefault   %formValues;           'unqualified'
+   attributeFormDefault %formValues;           'unqualified'
+   defaultAttributes    CDATA                  #IMPLIED
+   xpathDefaultNamespace    CDATA       '##local'
+   xml:lang             CDATA                  #IMPLIED
+   %schemaAttrs;>
+<!-- Note the xmlns declaration is NOT in the
+     schema for schema documents,
+     because at the Infoset level where schemas operate,
+     xmlns(:prefix) is NOT an attribute! -->
+<!-- The declaration of xmlns is a convenience for schema authors -->
+ 
+<!-- The id attribute here and below is for use in external references
+     from non-schemas using simple fragment identifiers.
+     It is NOT used for schema-to-schema reference, internal or
+     external. -->
+
+<!ELEMENT %defaultOpenContent; ((%annotation;)?, %any;)>
+<!ATTLIST %defaultOpenContent;
+          appliesToEmpty  (true|false)           'false'
+          mode            (interleave|suffix)    'interleave'
+          id              ID                     #IMPLIED
+          %defaultOpenContentAttrs;>
+
+<!-- a type is a named content type specification which allows attribute
+     declarations-->
+<!-- -->
+
+<!ELEMENT %complexType; ((%annotation;)?,
+                         (%simpleContent;|%complexContent;|
+                          %particleAndAttrs;))>
+
+<!ATTLIST %complexType;
+          name                    %NCName;                 #IMPLIED
+          id                      ID                       #IMPLIED
+          abstract                %boolean;                #IMPLIED
+          final                   %complexDerivationSet;   #IMPLIED
+          block                   %complexDerivationSet;   #IMPLIED
+          mixed                   (true|false)             'false'
+          defaultAttributesApply  %boolean;                'true'
+          %complexTypeAttrs;>
+
+<!-- particleAndAttrs is shorthand for a root type -->
+<!-- mixed is disallowed if simpleContent, overridden if complexContent has one too. -->
+
+<!-- If anyAttribute appears in one or more referenced attributeGroups
+     and/or explicitly, the intersection of the permissions is used -->
+
+<!ELEMENT %complexContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %complexContent;
+          mixed (true|false) #IMPLIED
+          id    ID           #IMPLIED
+          %complexContentAttrs;>
+
+<!ELEMENT %openContent; ((%annotation;)?, (%any;)?)>
+<!ATTLIST %openContent;
+          mode            (none|interleave|suffix)  'interleave'
+          id              ID                        #IMPLIED
+          %openContentAttrs;>
+
+<!-- restriction should use the branch defined above, not the simple
+     one from part2; extension should use the full model  -->
+
+<!ELEMENT %simpleContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %simpleContent;
+          id    ID           #IMPLIED
+          %simpleContentAttrs;>
+
+<!-- restriction should use the simple branch from part2, not the 
+     one defined above; extension should have no particle  -->
+
+<!ELEMENT %extension; ((%annotation;)?, (%particleAndAttrs;))>
+<!ATTLIST %extension;
+          base  %QName;               #REQUIRED
+          id    ID                    #IMPLIED
+          
+          %extensionAttrs;>
+
+<!-- an element is declared by either:
+ a name and a type (either nested or referenced via the type attribute)
+ or a ref to an existing element declaration -->
+
+<!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                     (%alternative;)*,
+                     (%unique; | %key; | %keyref;)*)>
+<!-- simpleType or complexType only if no type|ref attribute -->
+<!-- ref not allowed at top level -->
+<!ATTLIST %element;
+            name               %NCName;               #IMPLIED
+            id                 ID                     #IMPLIED
+            ref                %QName;                #IMPLIED
+            type               %QName;                #IMPLIED
+            minOccurs          %nonNegativeInteger;   #IMPLIED
+            maxOccurs          CDATA                  #IMPLIED
+            nillable           %boolean;              #IMPLIED
+            substitutionGroup  %QName;                #IMPLIED
+            abstract           %boolean;              #IMPLIED
+            final              %complexDerivationSet; #IMPLIED
+            block              %blockSet;             #IMPLIED
+            default            CDATA                  #IMPLIED
+            fixed              CDATA                  #IMPLIED
+            form               %formValues;           #IMPLIED
+            targetNamespace    %URIref;               #IMPLIED
+            %elementAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- In the absence of type AND ref, type defaults to type of
+     substitutionGroup, if any, else xs:anyType, i.e. unconstrained -->
+<!-- default and fixed are mutually exclusive -->
+
+<!ELEMENT %alternative; ((%annotation;)?, 
+            (%simpleType; | %complexType;)?) >
+<!ATTLIST %alternative; 
+            test                     CDATA     #IMPLIED
+            type                     %QName;   #IMPLIED
+            xpathDefaultNamespace    CDATA     #IMPLIED
+            id                       ID        #IMPLIED >
+
+
+<!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+<!ATTLIST %group; 
+          name        %NCName;               #IMPLIED
+          ref         %QName;                #IMPLIED
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %groupAttrs;>
+
+<!ELEMENT %all; ((%annotation;)?, (%element;| %group;| %any;)*)>
+<!ATTLIST %all;
+          minOccurs   (0 | 1)                #IMPLIED
+          maxOccurs   (0 | 1)                #IMPLIED
+          id          ID                     #IMPLIED
+          %allAttrs;>
+
+<!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %choice;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %choiceAttrs;>
+
+<!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %sequence;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %sequenceAttrs;>
+
+<!-- an anonymous grouping in a model, or
+     a top-level named group definition, or a reference to same -->
+
+
+<!ELEMENT %any; (%annotation;)?>
+<!ATTLIST %any;
+            namespace       CDATA                  #IMPLIED
+            notNamespace    CDATA                  #IMPLIED
+            notQName        CDATA                  ''
+            processContents (skip|lax|strict)      'strict'
+            minOccurs       %nonNegativeInteger;   '1'
+            maxOccurs       CDATA                  '1'
+            id              ID                     #IMPLIED
+            %anyAttrs;>
+
+<!-- namespace is interpreted as follows:
+                  ##any      - - any non-conflicting WFXML at all
+
+                  ##other    - - any non-conflicting WFXML from namespace other
+                                  than targetNamespace
+
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!-- notNamespace is interpreted as follows:
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!ELEMENT %anyAttribute; (%annotation;)?>
+<!ATTLIST %anyAttribute;
+            namespace       CDATA              #IMPLIED
+            notNamespace    CDATA              #IMPLIED
+            notQName        CDATA              ''
+            processContents (skip|lax|strict)  'strict'
+            id              ID                 #IMPLIED
+            %anyAttributeAttrs;>
+<!-- namespace and notNamespace are interpreted as for 'any' above -->
+
+<!-- simpleType only if no type|ref attribute -->
+<!-- ref not allowed at top level, name iff at top level -->
+<!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+<!ATTLIST %attribute;
+          name              %NCName;      #IMPLIED
+          id                ID            #IMPLIED
+          ref               %QName;       #IMPLIED
+          type              %QName;       #IMPLIED
+          use               (prohibited|optional|required) #IMPLIED
+          default           CDATA         #IMPLIED
+          fixed             CDATA         #IMPLIED
+          form              %formValues;  #IMPLIED
+          targetNamespace   %URIref;      #IMPLIED
+          inheritable       %boolean;      #IMPLIED
+          %attributeAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- default for use is optional when nested, none otherwise -->
+<!-- default and fixed are mutually exclusive -->
+<!-- type attr and simpleType content are mutually exclusive -->
+
+<!-- an attributeGroup is a named collection of attribute decls, or a
+     reference thereto -->
+<!ELEMENT %attributeGroup; ((%annotation;)?,
+                       (%attribute; | %attributeGroup;)*,
+                       (%anyAttribute;)?) >
+<!ATTLIST %attributeGroup;
+                 name       %NCName;       #IMPLIED
+                 id         ID             #IMPLIED
+                 ref        %QName;        #IMPLIED
+                 %attributeGroupAttrs;>
+
+<!-- ref iff no content, no name.  ref iff not top level -->
+
+<!-- better reference mechanisms -->
+<!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %unique;
+          name                     %NCName;       #IMPLIED
+          ref                      %QName;        #IMPLIED
+          id                       ID             #IMPLIED
+          %uniqueAttrs;>
+
+<!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %key;
+          name                     %NCName;       #IMPLIED
+          ref                      %QName;        #IMPLIED
+          id                       ID             #IMPLIED
+          %keyAttrs;>
+
+<!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %keyref;
+          name                     %NCName;       #IMPLIED
+          ref                      %QName;        #IMPLIED
+          refer                    %QName;        #IMPLIED
+          id                       ID             #IMPLIED
+          %keyrefAttrs;>
+
+<!ELEMENT %selector; ((%annotation;)?)>
+<!ATTLIST %selector;
+          xpath                    %XPathExpr; #REQUIRED
+          xpathDefaultNamespace    CDATA       #IMPLIED
+          id                       ID          #IMPLIED
+          %selectorAttrs;>
+<!ELEMENT %field; ((%annotation;)?)>
+<!ATTLIST %field;
+          xpath                    %XPathExpr; #REQUIRED
+          xpathDefaultNamespace    CDATA       #IMPLIED
+          id                       ID          #IMPLIED
+          %fieldAttrs;>
+
+<!-- co-constraint assertions -->
+<!ELEMENT %assert; ((%annotation;)?)>
+<!ATTLIST %assert;
+          test                     %XPathExpr; #REQUIRED
+          id                       ID          #IMPLIED
+          xpathDefaultNamespace    CDATA       #IMPLIED
+          %assertAttrs;>
+
+
+<!-- Schema combination mechanisms -->
+<!ELEMENT %include; (%annotation;)?>
+<!ATTLIST %include;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %includeAttrs;>
+
+<!ELEMENT %import; (%annotation;)?>
+<!ATTLIST %import;
+          namespace      %URIref; #IMPLIED
+          schemaLocation %URIref; #IMPLIED
+          id             ID       #IMPLIED
+          %importAttrs;>
+
+<!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                      %attributeGroup; | %group;)*>
+<!ATTLIST %redefine;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %redefineAttrs;>
+
+<!ELEMENT %override; ((%annotation;)?,
+                      ((%simpleType; | %complexType; | %group; | %attributeGroup;) |
+                       %element; | %attribute; | %notation;)*)>
+<!ATTLIST %override;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %overrideAttrs;>
+
+<!ELEMENT %notation; (%annotation;)?>
+<!ATTLIST %notation;
+	  name        %NCName;    #REQUIRED
+	  id          ID          #IMPLIED
+	  public      CDATA       #REQUIRED
+	  system      %URIref;    #IMPLIED
+	  %notationAttrs;>
+
+<!-- Annotation is either application information or documentation -->
+<!-- By having these here they are available for datatypes as well
+     as all the structures elements -->
+
+<!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+<!ATTLIST %annotation; %annotationAttrs;>
+
+<!-- User must define annotation elements in internal subset for this
+     to work -->
+<!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+<!ATTLIST %appinfo;
+          source     %URIref;      #IMPLIED
+          id         ID         #IMPLIED
+          %appinfoAttrs;>
+<!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+<!ATTLIST %documentation;
+          source     %URIref;   #IMPLIED
+          id         ID         #IMPLIED
+          xml:lang   CDATA      #IMPLIED
+          %documentationAttrs;>
+
+<!NOTATION XMLSchemaStructures PUBLIC
+           'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+<!NOTATION XML PUBLIC
+           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >
+
+<!-- 
+      In keeping with the XML Schema WG's standard versioning policy, 
+      this DTD will persist at the URI
+      http://www.w3.org/2012/04/XMLSchema.dtd.
+
+      At the date of issue it can also be found at the URI
+      http://www.w3.org/2009/XMLSchema/XMLSchema.dtd.
+
+      The schema document at that URI may however change in the future, 
+      in order to remain compatible with the latest version of XSD 
+      and its namespace.  In other words, if XSD or the XML Schema 
+      namespace change, the version of this document at 
+      http://www.w3.org/2009/XMLSchema/XMLSchema.dtd will change accordingly; 
+      the version at http://www.w3.org/2012/04/XMLSchema.dtd 
+      will not change.
+
+      Previous dated (and unchanging) versions of this DTD include:
+
+       http://www.w3.org/2012/01/XMLSchema.dtd
+          (XSD 1.1 Proposed Recommendation)
+
+
+        http://www.w3.org/2011/07/XMLSchema.dtd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2009/04/XMLSchema.dtd 
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2004/10/XMLSchema.dtd
+          (XSD 1.0 Recommendation, Second Edition)
+
+        http://www.w3.org/2001/05/XMLSchema.dtd
+          (XSD 1.0 Recommendation, First Edition)
+
+-->

--- a/api-generator/generator-interfaces/src/main/xsd-ref/XMLSchema.xsd
+++ b/api-generator/generator-interfaces/src/main/xsd-ref/XMLSchema.xsd
@@ -1,0 +1,1950 @@
+<?xml version='1.0'?>
+
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XSD 1.1//EN" "XMLSchema.dtd" [
+
+<!-- provide ID type information even for parsers which only read the
+     internal subset -->
+<!ATTLIST xs:schema          id  ID  #IMPLIED>
+<!ATTLIST xs:complexType     id  ID  #IMPLIED>
+<!ATTLIST xs:complexContent  id  ID  #IMPLIED>
+<!ATTLIST xs:simpleContent   id  ID  #IMPLIED>
+<!ATTLIST xs:extension       id  ID  #IMPLIED>
+<!ATTLIST xs:element         id  ID  #IMPLIED>
+<!ATTLIST xs:group           id  ID  #IMPLIED> 
+<!ATTLIST xs:all             id  ID  #IMPLIED>
+<!ATTLIST xs:choice          id  ID  #IMPLIED>
+<!ATTLIST xs:sequence        id  ID  #IMPLIED>
+<!ATTLIST xs:any             id  ID  #IMPLIED>
+<!ATTLIST xs:anyAttribute    id  ID  #IMPLIED>
+<!ATTLIST xs:attribute       id  ID  #IMPLIED>
+<!ATTLIST xs:attributeGroup  id  ID  #IMPLIED>
+<!ATTLIST xs:unique          id  ID  #IMPLIED>
+<!ATTLIST xs:key             id  ID  #IMPLIED>
+<!ATTLIST xs:keyref          id  ID  #IMPLIED>
+<!ATTLIST xs:selector        id  ID  #IMPLIED>
+<!ATTLIST xs:field           id  ID  #IMPLIED>
+<!ATTLIST xs:assert          id  ID  #IMPLIED>
+<!ATTLIST xs:include         id  ID  #IMPLIED>
+<!ATTLIST xs:import          id  ID  #IMPLIED>
+<!ATTLIST xs:redefine        id  ID  #IMPLIED>
+<!ATTLIST xs:override        id  ID  #IMPLIED>
+<!ATTLIST xs:notation        id  ID  #IMPLIED>
+<!--
+        Make sure that processors that do not read the external
+        subset will know about the various IDs we declare
+  -->
+        <!ATTLIST xs:simpleType id ID #IMPLIED>
+        <!ATTLIST xs:maxExclusive id ID #IMPLIED>
+        <!ATTLIST xs:minExclusive id ID #IMPLIED>
+        <!ATTLIST xs:maxInclusive id ID #IMPLIED>
+        <!ATTLIST xs:minInclusive id ID #IMPLIED>
+        <!ATTLIST xs:totalDigits id ID #IMPLIED>
+        <!ATTLIST xs:fractionDigits id ID #IMPLIED>
+        <!ATTLIST xs:length id ID #IMPLIED>
+        <!ATTLIST xs:minLength id ID #IMPLIED>
+        <!ATTLIST xs:maxLength id ID #IMPLIED>
+        <!ATTLIST xs:enumeration id ID #IMPLIED>
+        <!ATTLIST xs:pattern id ID #IMPLIED>
+        <!ATTLIST xs:assertion id ID #IMPLIED>
+        <!ATTLIST xs:explicitTimezone id ID #IMPLIED>
+        <!ATTLIST xs:appinfo id ID #IMPLIED>
+        <!ATTLIST xs:documentation id ID #IMPLIED>
+        <!ATTLIST xs:list id ID #IMPLIED>
+        <!ATTLIST xs:union id ID #IMPLIED>
+        ]>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified" xml:lang="EN"
+           targetNamespace="http://www.w3.org/2001/XMLSchema"
+           version="1.0">
+ <xs:annotation>
+  <xs:documentation>
+    Part 1 version: structures.xsd (rec-20120405)
+    Part 2 version: datatypes.xsd (rec-20120405)
+  </xs:documentation>
+ </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation  source="../structures/structures.html">
+   The schema corresponding to this document is normative,
+   with respect to the syntactic constraints it expresses in the
+   XML Schema Definition Language.  The documentation (within 'documentation' elements)
+   below, is not normative, but rather highlights important aspects of
+   the W3C Recommendation of which this is a part.
+
+      See below (at the bottom of this document) for information about
+      the revision and namespace-versioning policy governing this
+      schema document.
+
+    </xs:documentation>
+  </xs:annotation>
+  <xs:annotation>
+    <xs:documentation>
+   The simpleType element and all of its members are defined
+   towards the end of this schema document.</xs:documentation>
+ </xs:annotation>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/xml.xsd">
+    <xs:annotation>
+      <xs:documentation>
+       Get access to the xml: attribute groups for xml:lang
+       as declared on 'schema' and 'documentation' below
+     </xs:documentation>
+    </xs:annotation>
+  </xs:import>
+  <xs:complexType name="openAttrs">
+    <xs:annotation>
+      <xs:documentation>
+       This type is extended by almost all schema types
+       to allow attributes from other namespaces to be
+       added to user schemas.
+     </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="annotated">
+    <xs:annotation>
+      <xs:documentation>
+       This type is extended by all types which allow annotation
+       other than &lt;schema> itself
+     </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:openAttrs">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:ID"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="composition">
+    <xs:choice>
+      <xs:element ref="xs:include"/>
+      <xs:element ref="xs:import"/>
+      <xs:element ref="xs:redefine"/>
+      <xs:element ref="xs:override"/>
+      <xs:element ref="xs:annotation"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="schemaTop">
+    <xs:annotation>
+      <xs:documentation>
+   This group is for the
+   elements which occur freely at the top level of schemas.
+   All of their types are based on the "annotated" type by extension.</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:group ref="xs:redefinable"/>
+      <xs:element ref="xs:element"/>
+      <xs:element ref="xs:attribute"/>
+      <xs:element ref="xs:notation"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="redefinable">
+    <xs:annotation>
+      <xs:documentation>
+   This group is for the
+   elements which can self-redefine (see &lt;redefine> below).</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="xs:simpleType"/>
+      <xs:element ref="xs:complexType"/>
+      <xs:element ref="xs:group"/>
+      <xs:element ref="xs:attributeGroup"/>
+    </xs:choice>
+  </xs:group>
+  <xs:simpleType name="formChoice">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="qualified"/>
+      <xs:enumeration value="unqualified"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="reducedDerivationControl">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:derivationControl">
+      <xs:enumeration value="extension"/>
+      <xs:enumeration value="restriction"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="derivationSet">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+   #all or (possibly empty) subset of {extension, restriction}</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list itemType="xs:reducedDerivationControl"/>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="typeDerivationControl">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:derivationControl">
+      <xs:enumeration value="extension"/>
+      <xs:enumeration value="restriction"/>
+      <xs:enumeration value="list"/>
+      <xs:enumeration value="union"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="fullDerivationSet">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+   #all or (possibly empty) subset of {extension, restriction, list, union}</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list itemType="xs:typeDerivationControl"/>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:element name="schema" id="schema">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-schema"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:sequence>
+            <xs:group ref="xs:composition" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:sequence minOccurs="0">
+              <xs:element ref="xs:defaultOpenContent"/>
+              <xs:element ref="xs:annotation" minOccurs="0"
+                          maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="xs:schemaTop"/>
+              <xs:element ref="xs:annotation" minOccurs="0"
+                          maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:sequence>
+          <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+          <xs:attribute name="version" type="xs:token"/>
+          <xs:attribute name="finalDefault" type="xs:fullDerivationSet"
+                        default="" use="optional"/>
+          <xs:attribute name="blockDefault" type="xs:blockSet" default=""
+                        use="optional"/>
+          <xs:attribute name="attributeFormDefault" type="xs:formChoice"
+                        default="unqualified" use="optional"/>
+          <xs:attribute name="elementFormDefault" type="xs:formChoice"
+                        default="unqualified" use="optional"/>
+          <xs:attribute name="defaultAttributes" type="xs:QName"/>
+          <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"
+                        default="##local" use="optional"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+    <xs:key name="element">
+      <xs:selector xpath="xs:element"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="attribute">
+      <xs:selector xpath="xs:attribute"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="type">
+      <xs:selector xpath="xs:complexType|xs:simpleType"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="group">
+      <xs:selector xpath="xs:group"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="attributeGroup">
+      <xs:selector xpath="xs:attributeGroup"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="notation">
+      <xs:selector xpath="xs:notation"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="identityConstraint">
+      <xs:selector xpath=".//xs:key|.//xs:unique|.//xs:keyref"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+  </xs:element>
+  <xs:simpleType name="allNNI">
+    <xs:annotation>
+      <xs:documentation>
+   for maxOccurs</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xs:nonNegativeInteger">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="unbounded"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:attributeGroup name="occurs">
+    <xs:annotation>
+      <xs:documentation>
+   for all particles</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="minOccurs" type="xs:nonNegativeInteger" default="1"
+                  use="optional"/>
+    <xs:attribute name="maxOccurs" type="xs:allNNI" default="1" use="optional"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="defRef">
+    <xs:annotation>
+      <xs:documentation>
+   for element, group and attributeGroup,
+   which both define and reference</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:NCName"/>
+    <xs:attribute name="ref" type="xs:QName"/>
+  </xs:attributeGroup>
+  <xs:group name="typeDefParticle">
+    <xs:annotation>
+      <xs:documentation>
+   'complexType' uses this</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="group" type="xs:groupRef"/>
+      <xs:element ref="xs:all"/>
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="nestedParticle">
+    <xs:choice>
+      <xs:element name="element" type="xs:localElement"/>
+      <xs:element name="group" type="xs:groupRef"/>
+      
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+      <xs:element ref="xs:any"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="particle">
+    <xs:choice>
+      <xs:element name="element" type="xs:localElement"/>
+      <xs:element name="group" type="xs:groupRef"/>
+      <xs:element ref="xs:all"/>
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+      <xs:element ref="xs:any"/>
+    </xs:choice>
+  </xs:group>
+  <xs:complexType name="attribute">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="xs:defRef"/>
+        <xs:attribute name="type" type="xs:QName"/>
+        <xs:attribute name="use" default="optional" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:NMTOKEN">
+              <xs:enumeration value="prohibited"/>
+              <xs:enumeration value="optional"/>
+              <xs:enumeration value="required"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="default" type="xs:string"/>
+        <xs:attribute name="fixed" type="xs:string"/>
+        <xs:attribute name="form" type="xs:formChoice"/>
+        <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+          
+        <xs:attribute name="inheritable" type="xs:boolean"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelAttribute">
+    <xs:complexContent>
+      <xs:restriction base="xs:attribute">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:attribute name="form" use="prohibited"/>
+        <xs:attribute name="use" use="prohibited"/>
+        <xs:attribute name="targetNamespace" use="prohibited"/>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="inheritable" type="xs:boolean"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="attrDecls">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="attribute" type="xs:attribute"/>
+        <xs:element name="attributeGroup" type="xs:attributeGroupRef"/>
+      </xs:choice>
+      <xs:element ref="xs:anyAttribute" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="anyAttribute"  id="anyAttribute">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-anyAttribute"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:wildcard">
+          <xs:attribute name="notQName" type="xs:qnameListA"
+                        use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="assertions">
+    <xs:sequence>
+      <xs:element name="assert" type="xs:assertion"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="assertion">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:attribute name="test" type="xs:string"/>
+        <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="complexTypeModel">
+    <xs:choice>
+      <xs:element ref="xs:simpleContent"/>
+      <xs:element ref="xs:complexContent"/>
+      <xs:sequence>
+        <xs:annotation>
+          <xs:documentation>
+   This branch is short for
+   &lt;complexContent>
+   &lt;restriction base="xs:anyType">
+   ...
+   &lt;/restriction>
+   &lt;/complexContent></xs:documentation>
+        </xs:annotation>
+        <xs:element ref="xs:openContent" minOccurs="0"/>
+        <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+        <xs:group ref="xs:attrDecls"/>
+        <xs:group ref="xs:assertions"/>
+      </xs:sequence>
+    </xs:choice>
+  </xs:group>
+  <xs:complexType name="complexType" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:group ref="xs:complexTypeModel"/>
+        <xs:attribute name="name" type="xs:NCName">
+          <xs:annotation>
+            <xs:documentation>
+      Will be restricted to required or prohibited</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mixed" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+      Not allowed if simpleContent child is chosen.
+      May be overridden by setting on complexContent child.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="abstract" type="xs:boolean" default="false"
+                      use="optional"/>
+        <xs:attribute name="final" type="xs:derivationSet"/>
+        <xs:attribute name="block" type="xs:derivationSet"/>
+        <xs:attribute name="defaultAttributesApply" type="xs:boolean"
+                      default="true" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelComplexType">
+    <xs:complexContent>
+      <xs:restriction base="xs:complexType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:complexTypeModel"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="localComplexType">
+    <xs:complexContent>
+      <xs:restriction base="xs:complexType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:complexTypeModel"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:attribute name="abstract" use="prohibited"/>
+        <xs:attribute name="final" use="prohibited"/>
+        <xs:attribute name="block" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="restrictionType">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:choice minOccurs="0">
+            
+            <xs:sequence>
+              <xs:element ref="xs:openContent" minOccurs="0"/>
+              <xs:group ref="xs:typeDefParticle"/>
+            </xs:sequence>
+            <xs:group ref="xs:simpleRestrictionModel"/>
+          </xs:choice>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:attribute name="base" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="complexRestrictionType">
+    <xs:complexContent>
+      <xs:restriction base="xs:restrictionType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>This choice is added simply to
+                   make this a valid restriction per the REC</xs:documentation>
+            </xs:annotation>
+            
+            <xs:sequence>
+              <xs:element ref="xs:openContent" minOccurs="0"/>
+              <xs:group ref="xs:typeDefParticle"/>
+            </xs:sequence>
+          </xs:choice>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="extensionType">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:element ref="xs:openContent" minOccurs="0"/>
+          <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:attribute name="base" type="xs:QName" use="required"/>
+        
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="complexContent" id="complexContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-complexContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:choice>
+            <xs:element name="restriction" type="xs:complexRestrictionType"/>
+            <xs:element name="extension" type="xs:extensionType"/>
+          </xs:choice>
+          <xs:attribute name="mixed" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+       Overrides any setting on complexType parent.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="openContent" id="openContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-openContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="any" minOccurs="0" type="xs:wildcard"/>
+          </xs:sequence>
+          <xs:attribute name="mode" default="interleave" use="optional">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="interleave"/>
+                <xs:enumeration value="suffix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="defaultOpenContent" id="defaultOpenContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-defaultOpenContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="any" type="xs:wildcard"/>
+          </xs:sequence>
+          <xs:attribute name="appliesToEmpty" type="xs:boolean"
+                        default="false" use="optional"/>
+          <xs:attribute name="mode" default="interleave" use="optional">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="interleave"/>
+                <xs:enumeration value="suffix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="simpleRestrictionType">
+    <xs:complexContent>
+      <xs:restriction base="xs:restrictionType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>This choice is added simply to
+                   make this a valid restriction per the REC</xs:documentation>
+            </xs:annotation>
+            <xs:group ref="xs:simpleRestrictionModel"/>
+          </xs:choice>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="simpleExtensionType">
+    <xs:complexContent>
+      <xs:restriction base="xs:extensionType">
+        <xs:sequence>
+          <xs:annotation>
+            <xs:documentation>
+      No typeDefParticle group reference</xs:documentation>
+          </xs:annotation>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="simpleContent" id="simpleContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-simpleContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:choice>
+            <xs:element name="restriction" type="xs:simpleRestrictionType"/>
+            <xs:element name="extension" type="xs:simpleExtensionType"/>
+          </xs:choice>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="complexType" type="xs:topLevelComplexType" id="complexType">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-complexType"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:simpleType name="blockSet">
+    <xs:annotation>
+      <xs:documentation>
+    A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+    #all or (possibly empty) subset of {substitution, extension,
+    restriction}</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list>
+          <xs:simpleType>
+            <xs:restriction base="xs:derivationControl">
+              <xs:enumeration value="extension"/>
+              <xs:enumeration value="restriction"/>
+              <xs:enumeration value="substitution"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:list>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:complexType name="element" abstract="true">
+    <xs:annotation>
+      <xs:documentation>
+   The element element can be used either
+   at the top level to define an element-type binding globally,
+   or within a content model to either reference a globally-defined
+   element or type or declare an element-type binding locally.
+   The ref form is not allowed at the top level.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:choice minOccurs="0">
+            <xs:element name="simpleType" type="xs:localSimpleType"/>
+            <xs:element name="complexType" type="xs:localComplexType"/>
+          </xs:choice>
+          <xs:element name="alternative" type="xs:altType" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xs:identityConstraint" minOccurs="0"
+                    maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="xs:defRef"/>
+        <xs:attribute name="type" type="xs:QName"/>
+        
+        <xs:attribute name="substitutionGroup">
+         <xs:simpleType>
+          <xs:list itemType="xs:QName"/>
+         </xs:simpleType>
+        </xs:attribute>
+        <xs:attributeGroup ref="xs:occurs"/>
+        <xs:attribute name="default" type="xs:string"/>
+        <xs:attribute name="fixed" type="xs:string"/>
+        <xs:attribute name="nillable" type="xs:boolean" use="optional"/>
+        <xs:attribute name="abstract" type="xs:boolean" default="false"
+                      use="optional"/>
+        <xs:attribute name="final" type="xs:derivationSet"/>
+        <xs:attribute name="block" type="xs:blockSet"/>
+        <xs:attribute name="form" type="xs:formChoice"/>
+        <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelElement">
+    <xs:complexContent>
+      <xs:restriction base="xs:element">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:element name="simpleType" type="xs:localSimpleType"/>
+            <xs:element name="complexType" type="xs:localComplexType"/>
+          </xs:choice>
+          <xs:element name="alternative" type="xs:altType" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xs:identityConstraint" minOccurs="0"
+                    maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:attribute name="form" use="prohibited"/>
+        <xs:attribute name="targetNamespace" use="prohibited"/>
+        <xs:attribute name="minOccurs" use="prohibited"/>
+        <xs:attribute name="maxOccurs" use="prohibited"/>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="localElement">
+    <xs:complexContent>
+      <xs:restriction base="xs:element">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:element name="simpleType" type="xs:localSimpleType"/>
+            <xs:element name="complexType" type="xs:localComplexType"/>
+          </xs:choice>
+          <xs:element name="alternative" type="xs:altType" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xs:identityConstraint" minOccurs="0"
+                    maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="substitutionGroup" use="prohibited"/>
+        <xs:attribute name="final" use="prohibited"/>
+        <xs:attribute name="abstract" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="element" type="xs:topLevelElement" id="element">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-element"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="altType">
+    <xs:annotation>
+      <xs:documentation>
+        This type is used for 'alternative' elements.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:choice minOccurs="0">
+          <xs:element name="simpleType" type="xs:localSimpleType"/>
+          <xs:element name="complexType" type="xs:localComplexType"/>
+        </xs:choice>
+        <xs:attribute name="test" type="xs:string" use="optional"/>
+        <xs:attribute name="type" type="xs:QName" use="optional"/>
+        <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="group" abstract="true">
+    <xs:annotation>
+      <xs:documentation>
+   group type for explicit groups, named top-level groups and
+   group references</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        
+          <xs:group ref="xs:particle" minOccurs="0" maxOccurs="unbounded"/>
+          
+        <xs:attributeGroup ref="xs:defRef"/>
+        <xs:attributeGroup ref="xs:occurs"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="realGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:group">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0" maxOccurs="1">
+            <xs:element ref="xs:all"/>
+            <xs:element ref="xs:choice"/>
+            <xs:element ref="xs:sequence"/>
+          </xs:choice>
+          
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="namedGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:realGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="all">
+              <xs:complexType>
+                <xs:complexContent>
+                  <xs:restriction base="xs:all">
+                    <xs:group ref="xs:allModel"/>
+                    <xs:attribute name="minOccurs" use="prohibited"/>
+                    <xs:attribute name="maxOccurs" use="prohibited"/>
+                    <xs:anyAttribute namespace="##other" processContents="lax"/>
+                  </xs:restriction>
+                </xs:complexContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="choice" type="xs:simpleExplicitGroup"/>
+            <xs:element name="sequence" type="xs:simpleExplicitGroup"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:attribute name="minOccurs" use="prohibited"/>
+        <xs:attribute name="maxOccurs" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="groupRef">
+    <xs:complexContent>
+      <xs:restriction base="xs:realGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="ref" type="xs:QName" use="required"/>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="explicitGroup">
+    <xs:annotation>
+      <xs:documentation>
+   group type for the three kinds of group</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="xs:group">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="simpleExplicitGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:explicitGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="minOccurs" use="prohibited"/>
+        <xs:attribute name="maxOccurs" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="allModel">
+    <xs:sequence>
+      <xs:element ref="xs:annotation" minOccurs="0"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>This choice with min/max is here to
+                          avoid a pblm with the Elt:All/Choice/Seq
+                          Particle derivation constraint</xs:documentation>
+        </xs:annotation>
+        <xs:element name="element" type="xs:localElement"/>
+        <xs:element ref="xs:any"/>
+        <xs:element name="group">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:restriction base="xs:groupRef">
+                <xs:sequence>
+                  <xs:element ref="xs:annotation" minOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="minOccurs" fixed="1" type="xs:nonNegativeInteger"/>
+                <xs:attribute name="maxOccurs" fixed="1" type="xs:nonNegativeInteger"/>
+              </xs:restriction>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="all">
+    <xs:annotation>
+      <xs:documentation>
+   Only elements allowed inside</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="xs:explicitGroup">
+        <xs:group ref="xs:allModel"/>
+        <xs:attribute name="minOccurs" default="1" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:nonNegativeInteger">
+              <xs:enumeration value="0"/>
+              <xs:enumeration value="1"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="maxOccurs" default="1" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:allNNI">
+              <xs:enumeration value="0"/>
+              <xs:enumeration value="1"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="all" type="xs:all" id="all">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-all"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="choice" type="xs:explicitGroup" id="choice">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-choice"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="sequence" type="xs:explicitGroup" id="sequence">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-sequence"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="group" type="xs:namedGroup" id="group">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-group"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:attributeGroup name="anyAttrGroup">
+    <xs:attribute name="namespace" type="xs:namespaceList"
+                  use="optional"/>
+    <xs:attribute name="notNamespace" use="optional">
+      <xs:simpleType>
+        <xs:restriction base="xs:basicNamespaceList">
+          <xs:minLength value="1"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="processContents" default="strict" use="optional">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="skip"/>
+          <xs:enumeration value="lax"/>
+          <xs:enumeration value="strict"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:complexType name="wildcard">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        
+         <xs:attributeGroup ref="xs:anyAttrGroup"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="any" id="any">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-any"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:wildcard">
+          <xs:attribute name="notQName" type="xs:qnameList"
+                        use="optional"/>
+          <xs:attributeGroup ref="xs:occurs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:annotation>
+    <xs:documentation>
+   simple type for the value of the 'namespace' attr of
+   'any' and 'anyAttribute'</xs:documentation>
+  </xs:annotation>
+  <xs:annotation>
+    <xs:documentation>
+   Value is
+              ##any      - - any non-conflicting WFXML/attribute at all
+
+              ##other    - - any non-conflicting WFXML/attribute from
+                              namespace other than targetNS
+
+              ##local    - - any unqualified non-conflicting WFXML/attribute 
+
+              one or     - - any non-conflicting WFXML/attribute from
+              more URI        the listed namespaces
+              references
+              (space separated)
+
+    ##targetNamespace or ##local may appear in the above list, to
+        refer to the targetNamespace of the enclosing
+        schema or an absent targetNamespace respectively</xs:documentation>
+  </xs:annotation>
+  <xs:simpleType name="namespaceList">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    
+    <xs:union memberTypes="xs:specialNamespaceList xs:basicNamespaceList" />
+  </xs:simpleType>
+  <xs:simpleType name="basicNamespaceList">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:list>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:anyURI">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="##targetNamespace"/>
+              <xs:enumeration value="##local"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:list>
+  </xs:simpleType>
+  <xs:simpleType name="specialNamespaceList">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="##any"/>
+      <xs:enumeration value="##other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="qnameList">
+    <xs:annotation>
+      <xs:documentation>
+        A utility type, not for public use
+      </xs:documentation>
+    </xs:annotation>
+    <xs:list>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:QName">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="##defined"/>
+              <xs:enumeration value="##definedSibling"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:list>
+  </xs:simpleType>
+  <xs:simpleType name="qnameListA">
+    <xs:annotation>
+      <xs:documentation>
+        A utility type, not for public use
+      </xs:documentation>
+    </xs:annotation>
+    <xs:list>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:QName">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="##defined"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:list>
+  </xs:simpleType>
+  <xs:simpleType name="xpathDefaultNamespace">
+    <xs:union memberTypes="xs:anyURI">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="##defaultNamespace"/>
+          <xs:enumeration value="##targetNamespace"/>
+          <xs:enumeration value="##local"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:element name="attribute" type="xs:topLevelAttribute" id="attribute">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-attribute"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="attributeGroup" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        
+          <xs:group ref="xs:attrDecls"/>
+          
+        <xs:attributeGroup ref="xs:defRef"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="namedAttributeGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:attributeGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:attrDecls"/>
+          
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="attributeGroupRef">
+    <xs:complexContent>
+      <xs:restriction base="xs:attributeGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="ref" type="xs:QName" use="required"/>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="attributeGroup" type="xs:namedAttributeGroup"
+              id="attributeGroup">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-attributeGroup"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="include" id="include">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-include"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="redefine" id="redefine">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-redefine"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xs:annotation"/>
+            <xs:group ref="xs:redefinable"/>
+          </xs:choice>
+          <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="override" id="override">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-override"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+            <xs:group ref="xs:schemaTop" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="import" id="import">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-import"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="namespace" type="xs:anyURI"/>
+          <xs:attribute name="schemaLocation" type="xs:anyURI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="selector" id="selector">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-selector"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="xpath" use="required">
+            <xs:simpleType>
+              <xs:annotation>
+                <xs:documentation>A subset of XPath expressions for use
+in selectors</xs:documentation>
+                <xs:documentation>A utility type, not for public
+use</xs:documentation>
+              </xs:annotation>
+              <xs:restriction base="xs:token"/>
+                
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="field" id="field">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-field"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="xpath" use="required">
+            <xs:simpleType>
+              <xs:annotation>
+                <xs:documentation>A subset of XPath expressions for use
+in fields</xs:documentation>
+                <xs:documentation>A utility type, not for public
+use</xs:documentation>
+              </xs:annotation>
+              <xs:restriction base="xs:token"/>
+                
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="keybase">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence minOccurs="0">
+          <xs:element ref="xs:selector"/>
+          <xs:element ref="xs:field" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName"/>
+        <xs:attribute name="ref" type="xs:QName"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="identityConstraint">
+    <xs:annotation>
+      <xs:documentation>The three kinds of identity constraints, all with
+                     type of or derived from 'keybase'.
+   </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="xs:unique"/>
+      <xs:element ref="xs:key"/>
+      <xs:element ref="xs:keyref"/>
+    </xs:choice>
+  </xs:group>
+  <xs:element name="unique" type="xs:keybase" id="unique">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-unique"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="key" type="xs:keybase" id="key">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-key"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="keyref" id="keyref">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-keyref"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:keybase">
+          <xs:attribute name="refer" type="xs:QName"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="notation" id="notation">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-notation"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="name" type="xs:NCName" use="required"/>
+          <xs:attribute name="public" type="xs:public"/>
+          <xs:attribute name="system" type="xs:anyURI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="public">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+   A public identifier, per ISO 8879</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token"/>
+  </xs:simpleType>
+  <xs:element name="appinfo" id="appinfo">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-appinfo"/>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:any processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="source" type="xs:anyURI"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="documentation" id="documentation">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-documentation"/>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:any processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="source" type="xs:anyURI"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="annotation" id="annotation">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-annotation"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xs:appinfo"/>
+            <xs:element ref="xs:documentation"/>
+          </xs:choice>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:annotation>
+    <xs:documentation>
+   notations for use within  schema documents</xs:documentation>
+  </xs:annotation>
+  <xs:notation name="XMLSchemaStructures" public="structures"
+               system="http://www.w3.org/2000/08/XMLSchema.xsd"/>
+  <xs:notation name="XML" public="REC-xml-19980210"
+               system="http://www.w3.org/TR/1998/REC-xml-19980210"/>
+  <xs:complexType name="anyType" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+   Not the real urType, but as close an approximation as we can
+   get in the XML representation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:anyAttribute processContents="lax"/>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+      In keeping with the XML Schema WG's standard versioning policy, 
+      the material in this schema document will persist at the URI
+      http://www.w3.org/2012/04/XMLSchema.xsd.
+
+      At the date of issue it can also be found at the URI
+      http://www.w3.org/2009/XMLSchema/XMLSchema.xsd.
+
+      The schema document at that URI may however change in the future, 
+      in order to remain compatible with the latest version of XSD 
+      and its namespace.  In other words, if XSD or the XML Schema 
+      namespace change, the version of this document at 
+      http://www.w3.org/2009/XMLSchema/XMLSchema.xsd will change accordingly; 
+      the version at http://www.w3.org/2012/04/XMLSchema.xsd will not change.
+
+      Previous dated (and unchanging) versions of this schema document 
+      include:
+
+       http://www.w3.org/2012/01/XMLSchema.xsd
+          (XSD 1.1 Proposed Recommendation)
+
+        http://www.w3.org/2011/07/XMLSchema.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2009/04/XMLSchema.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2004/10/XMLSchema.xsd
+          (XSD 1.0 Recommendation, Second Edition)
+
+        http://www.w3.org/2001/05/XMLSchema.xsd
+          (XSD 1.0 Recommendation, First Edition)
+
+
+    </xs:documentation>
+  </xs:annotation>
+
+
+
+
+  <xs:simpleType name="derivationControl">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="substitution"/>
+      <xs:enumeration value="extension"/>
+      <xs:enumeration value="restriction"/>
+      <xs:enumeration value="list"/>
+      <xs:enumeration value="union"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="simpleDerivation">
+    <xs:choice>
+      <xs:element ref="xs:restriction"/>
+      <xs:element ref="xs:list"/>
+      <xs:element ref="xs:union"/>
+    </xs:choice>
+  </xs:group>
+  <xs:simpleType name="simpleDerivationSet">
+    <xs:annotation>
+      <xs:documentation>
+   #all or (possibly empty) subset of {restriction, extension, union, list}
+   </xs:documentation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list>
+          <xs:simpleType>
+            <xs:restriction base="xs:derivationControl">
+              <xs:enumeration value="list"/>
+              <xs:enumeration value="union"/>
+              <xs:enumeration value="restriction"/>
+              <xs:enumeration value="extension"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:list>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:complexType name="simpleType" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:group ref="xs:simpleDerivation"/>
+        <xs:attribute name="final" type="xs:simpleDerivationSet"/>
+        <xs:attribute name="name" type="xs:NCName">
+          <xs:annotation>
+            <xs:documentation>
+              Can be restricted to required or forbidden
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelSimpleType">
+    <xs:complexContent>
+      <xs:restriction base="xs:simpleType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:simpleDerivation"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required">
+          <xs:annotation>
+            <xs:documentation>
+              Required at the top level
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="localSimpleType">
+    <xs:complexContent>
+      <xs:restriction base="xs:simpleType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:simpleDerivation"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="prohibited">
+          <xs:annotation>
+            <xs:documentation>
+              Forbidden when nested
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="simpleType" type="xs:topLevelSimpleType" id="simpleType">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-simpleType"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="facet" abstract="true">
+    <xs:annotation>
+      <xs:documentation>
+        An abstract element, representing facets in general.
+        The facets defined by this spec are substitutable for
+        this element, and implementation-defined facets should
+        also name this as a substitution-group head.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:group name="simpleRestrictionModel">
+    <xs:sequence>
+      <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+      <xs:choice minOccurs="0" 
+          maxOccurs="unbounded">
+        <xs:element ref="xs:facet"/>
+        <xs:any processContents="lax"
+            namespace="##other"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="restriction" id="restriction">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation
+             source="http://www.w3.org/TR/xmlschema11-2/#element-restriction">
+          base attribute and simpleType child are mutually
+          exclusive, but one or other is required
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:group ref="xs:simpleRestrictionModel"/>
+          <xs:attribute name="base" type="xs:QName" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="list" id="list">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation
+             source="http://www.w3.org/TR/xmlschema11-2/#element-list">
+          itemType attribute and simpleType child are mutually
+          exclusive, but one or other is required
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="simpleType" type="xs:localSimpleType"
+                        minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="itemType" type="xs:QName" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="union" id="union">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation
+             source="http://www.w3.org/TR/xmlschema11-2/#element-union">
+          memberTypes attribute must be non-empty or there must be
+          at least one simpleType child
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="simpleType" type="xs:localSimpleType"
+                        minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="memberTypes" use="optional">
+            <xs:simpleType>
+              <xs:list itemType="xs:QName"/>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="facet">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:attribute name="value" use="required"/>
+        <xs:attribute name="fixed" type="xs:boolean" default="false"
+                      use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="noFixedFacet">
+    <xs:complexContent>
+      <xs:restriction base="xs:facet">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="fixed" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="minExclusive" type="xs:facet"  
+    id="minExclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-minExclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="minInclusive" type="xs:facet" 
+    id="minInclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-minInclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxExclusive" type="xs:facet" 
+    id="maxExclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-maxExclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxInclusive" type="xs:facet"  
+    id="maxInclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-maxInclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="numFacet">
+    <xs:complexContent>
+      <xs:restriction base="xs:facet">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="value"  
+            type="xs:nonNegativeInteger" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="intFacet">
+    <xs:complexContent>
+      <xs:restriction base="xs:facet">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="value" type="xs:integer" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="totalDigits" id="totalDigits"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-totalDigits"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:numFacet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="xs:positiveInteger" use="required"/>
+          <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fractionDigits" type="xs:numFacet"  
+    id="fractionDigits"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-fractionDigits"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="length" type="xs:numFacet" id="length"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-length"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="minLength" type="xs:numFacet"  
+    id="minLength"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-minLength"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxLength" type="xs:numFacet"  
+    id="maxLength"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-maxLength"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="enumeration" type="xs:noFixedFacet"  
+    id="enumeration"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-enumeration"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="whiteSpace" id="whiteSpace"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-whiteSpace"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:facet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="preserve"/>
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="collapse"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pattern" id="pattern"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-pattern"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:noFixedFacet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="xs:string"  
+              use="required"/>
+          <xs:anyAttribute namespace="##other"  
+              processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="assertion" type="xs:assertion"
+              id="assertion" substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-assertion"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="explicitTimezone" id="explicitTimezone"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-explicitTimezone"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:facet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="optional"/>
+                <xs:enumeration value="required"/>
+                <xs:enumeration value="prohibited"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+      In keeping with the XML Schema WG's standard versioning policy, 
+      this schema document will persist at the URI
+      http://www.w3.org/2012/04/datatypes.xsd.
+
+      At the date of issue it can also be found at the URI
+      http://www.w3.org/2009/XMLSchema/datatypes.xsd.
+
+      The schema document at that URI may however change in the future, 
+      in order to remain compatible with the latest version of XSD 
+      and its namespace.  In other words, if XSD or the XML Schema 
+      namespace change, the version of this document at 
+      http://www.w3.org/2009/XMLSchema/datatypes.xsd will change accordingly; 
+      the version at http://www.w3.org/2012/04/datatypes.xsd will not change.
+
+      Previous dated (and unchanging) versions of this schema document 
+      include:
+
+        http://www.w3.org/2012/01/datatypes.xsd
+          (XSD 1.1 Proposed Recommendation)
+
+        http://www.w3.org/2011/07/datatypes.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2009/04/datatypes.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2004/10/datatypes.xsd
+          (XSD 1.0 Recommendation, Second Edition)
+
+        http://www.w3.org/2001/05/datatypes.xsd
+          (XSD 1.0 Recommendation, First Edition)
+
+    </xs:documentation>
+  </xs:annotation>
+
+
+
+</xs:schema>

--- a/api-generator/generator-interfaces/src/main/xsd-ref/datatypes.dtd
+++ b/api-generator/generator-interfaces/src/main/xsd-ref/datatypes.dtd
@@ -1,0 +1,222 @@
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+        
+        Id: datatypes.dtd,v 1.1.2.4 2005/01/31 18:40:42 cmsmcq Exp 
+        Note this DTD is NOT normative, or even definitive.
+  -->
+
+<!--
+        This DTD cannot be used on its own, it is intended
+        only for incorporation in XMLSchema.dtd, q.v.
+  -->
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % simpleType "%p;simpleType">
+<!ENTITY % restriction "%p;restriction">
+<!ENTITY % list "%p;list">
+<!ENTITY % union "%p;union">
+<!ENTITY % maxExclusive "%p;maxExclusive">
+<!ENTITY % minExclusive "%p;minExclusive">
+<!ENTITY % maxInclusive "%p;maxInclusive">
+<!ENTITY % minInclusive "%p;minInclusive">
+<!ENTITY % totalDigits "%p;totalDigits">
+<!ENTITY % fractionDigits "%p;fractionDigits">
+
+<!ENTITY % length "%p;length">
+<!ENTITY % minLength "%p;minLength">
+<!ENTITY % maxLength "%p;maxLength">
+<!ENTITY % enumeration "%p;enumeration">
+<!ENTITY % whiteSpace "%p;whiteSpace">
+<!ENTITY % pattern "%p;pattern">
+
+<!ENTITY % assertion "%p;assertion">
+
+<!ENTITY % explicitTimezone "%p;explicitTimezone">
+
+
+<!--
+        Customization entities for the ATTLIST of each element
+        type. Define one of these if your schema takes advantage
+        of the anyAttribute='##other' in the schema for schemas
+  -->
+
+<!ENTITY % simpleTypeAttrs "">
+<!ENTITY % restrictionAttrs "">
+<!ENTITY % listAttrs "">
+<!ENTITY % unionAttrs "">
+<!ENTITY % maxExclusiveAttrs "">
+<!ENTITY % minExclusiveAttrs "">
+<!ENTITY % maxInclusiveAttrs "">
+<!ENTITY % minInclusiveAttrs "">
+<!ENTITY % totalDigitsAttrs "">
+<!ENTITY % fractionDigitsAttrs "">
+<!ENTITY % lengthAttrs "">
+<!ENTITY % minLengthAttrs "">
+<!ENTITY % maxLengthAttrs "">
+
+<!ENTITY % enumerationAttrs "">
+<!ENTITY % whiteSpaceAttrs "">
+<!ENTITY % patternAttrs "">
+<!ENTITY % assertionAttrs "">
+<!ENTITY % explicitTimezoneAttrs "">
+
+<!-- Define some entities for informative use as attribute
+        types -->
+<!ENTITY % URIref "CDATA">
+<!ENTITY % XPathExpr "CDATA">
+<!ENTITY % QName "NMTOKEN">
+<!ENTITY % QNames "NMTOKENS">
+<!ENTITY % NCName "NMTOKEN">
+<!ENTITY % nonNegativeInteger "NMTOKEN">
+<!ENTITY % boolean "(true|false)">
+<!ENTITY % simpleDerivationSet "CDATA">
+<!--
+        #all or space-separated list drawn from derivationChoice
+  -->
+
+<!--
+        Note that the use of 'facet' below is less restrictive
+        than is really intended:  There should in fact be no
+        more than one of each of minInclusive, minExclusive,
+        maxInclusive, maxExclusive, totalDigits, fractionDigits,
+        length, maxLength, minLength within datatype,
+        and the min- and max- variants of Inclusive and Exclusive
+        are mutually exclusive. On the other hand,  pattern and
+        enumeration and assertion may repeat.
+  -->
+<!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+<!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+<!ENTITY % bounds "%minBound; | %maxBound;">
+<!ENTITY % numeric "%totalDigits; | %fractionDigits;"> 
+<!ENTITY % ordered "%bounds; | %numeric;">
+<!ENTITY % unordered
+   "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength; | %assertion;
+   | %explicitTimezone;">
+<!ENTITY % implementation-defined-facets "">
+<!ENTITY % facet "%ordered; | %unordered; %implementation-defined-facets;">
+<!ENTITY % facetAttr 
+        "value CDATA #REQUIRED
+        id ID #IMPLIED">
+<!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+<!ENTITY % facetModel "(%annotation;)?">
+<!ELEMENT %simpleType;
+        ((%annotation;)?, (%restriction; | %list; | %union;))>
+<!ATTLIST %simpleType;
+    name      %NCName; #IMPLIED
+    final     %simpleDerivationSet; #IMPLIED
+    id        ID       #IMPLIED
+    %simpleTypeAttrs;>
+<!-- name is required at top level -->
+<!ELEMENT %restriction; ((%annotation;)?,
+                         (%restriction1; |
+                          ((%simpleType;)?,(%facet;)*)),
+                         (%attrDecls;))>
+<!ATTLIST %restriction;
+    base      %QName;                  #IMPLIED
+    id        ID       #IMPLIED
+    %restrictionAttrs;>
+<!--
+        base and simpleType child are mutually exclusive,
+        one is required.
+
+        restriction is shared between simpleType and
+        simpleContent and complexContent (in XMLSchema.xsd).
+        restriction1 is for the latter cases, when this
+        is restricting a complex type, as is attrDecls.
+  -->
+<!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+<!ATTLIST %list;
+    itemType      %QName;             #IMPLIED
+    id        ID       #IMPLIED
+    %listAttrs;>
+<!--
+        itemType and simpleType child are mutually exclusive,
+        one is required
+  -->
+<!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+<!ATTLIST %union;
+    id            ID       #IMPLIED
+    memberTypes   %QNames;            #IMPLIED
+    %unionAttrs;>
+<!--
+        At least one item in memberTypes or one simpleType
+        child is required
+  -->
+
+<!ELEMENT %maxExclusive; %facetModel;>
+<!ATTLIST %maxExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxExclusiveAttrs;>
+<!ELEMENT %minExclusive; %facetModel;>
+<!ATTLIST %minExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minExclusiveAttrs;>
+
+<!ELEMENT %maxInclusive; %facetModel;>
+<!ATTLIST %maxInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxInclusiveAttrs;>
+<!ELEMENT %minInclusive; %facetModel;>
+<!ATTLIST %minInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minInclusiveAttrs;>
+
+<!ELEMENT %totalDigits; %facetModel;>
+<!ATTLIST %totalDigits;
+        %facetAttr;
+        %fixedAttr;
+        %totalDigitsAttrs;>
+<!ELEMENT %fractionDigits; %facetModel;>
+<!ATTLIST %fractionDigits;
+        %facetAttr;
+        %fixedAttr;
+        %fractionDigitsAttrs;>
+
+<!ELEMENT %length; %facetModel;>
+<!ATTLIST %length;
+        %facetAttr;
+        %fixedAttr;
+        %lengthAttrs;>
+<!ELEMENT %minLength; %facetModel;>
+<!ATTLIST %minLength;
+        %facetAttr;
+        %fixedAttr;
+        %minLengthAttrs;>
+<!ELEMENT %maxLength; %facetModel;>
+<!ATTLIST %maxLength;
+        %facetAttr;
+        %fixedAttr;
+        %maxLengthAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %enumeration; %facetModel;>
+<!ATTLIST %enumeration;
+        %facetAttr;
+        %enumerationAttrs;>
+
+<!ELEMENT %whiteSpace; %facetModel;>
+<!ATTLIST %whiteSpace;
+        %facetAttr;
+        %fixedAttr;
+        %whiteSpaceAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %pattern; %facetModel;>
+<!ATTLIST %pattern;
+        %facetAttr;
+        %patternAttrs;>
+
+<!ELEMENT %assertion; %facetModel;>
+<!ATTLIST %assertion;
+        %facetAttr;
+        %assertionAttrs;>
+
+<!ELEMENT %explicitTimezone; %facetModel;>
+<!ATTLIST %explicitTimezone;
+        %facetAttr;
+        %explicitTimezoneAttrs;>

--- a/api-generator/generator-java/pom.xml
+++ b/api-generator/generator-java/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>generator-java</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API Generator - Java</name>

--- a/api-generator/generator-java/pom.xml
+++ b/api-generator/generator-java/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>generator-java</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API Generator - Java</name>

--- a/api-generator/pom.xml
+++ b/api-generator/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>api-generator</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA MO API Generator</name>
   

--- a/api-generator/pom.xml
+++ b/api-generator/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>api-generator</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA MO API Generator</name>
   

--- a/apis/api-area001-v003-mal/pom.xml
+++ b/apis/api-area001-v003-mal/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area001-v003-mal</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MAL v003</name>

--- a/apis/api-area001-v003-mal/pom.xml
+++ b/apis/api-area001-v003-mal/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area001-v003-mal</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MAL v003</name>

--- a/apis/api-area001-v003-mal/src/main/java/org/ccsds/moims/mo/mal/helpertools/helpers/HelperMisc.java
+++ b/apis/api-area001-v003-mal/src/main/java/org/ccsds/moims/mo/mal/helpertools/helpers/HelperMisc.java
@@ -124,6 +124,16 @@ public class HelperMisc {
      * @throws IOException if the file consumer properties file does no exist
      */
     public static void loadConsumerProperties() throws MalformedURLException, IOException {
+        // Were they loaded already? This flag is independent from the provider's
+        // "PropertiesLoadedFlag" so that an application acting as both a consumer
+        // and a provider still loads both property files.
+        String propAreLoaded = System.getProperty("ConsumerPropertiesLoadedFlag");
+        if (propAreLoaded != null) {
+            if (propAreLoaded.equals("true")) {
+                return;
+            }
+        }
+
         final Properties sysProps = System.getProperties();
         final File file = new File(System.getProperty("consumer.properties", CONSUMER_PROPERTIES_FILE));
 
@@ -134,6 +144,7 @@ public class HelperMisc {
         }
 
         System.setProperties(sysProps);
+        System.setProperty("ConsumerPropertiesLoadedFlag", "true");
     }
 
     /**

--- a/apis/api-area001-v003-mal/src/main/java/org/ccsds/moims/mo/mal/helpertools/helpers/HelperMisc.java
+++ b/apis/api-area001-v003-mal/src/main/java/org/ccsds/moims/mo/mal/helpertools/helpers/HelperMisc.java
@@ -229,7 +229,6 @@ public class HelperMisc {
      * SHARED_BROKER_PROPERTIES file will be read
      */
     public static void loadPropertiesFile(Boolean useSharedBroker) {
-
         // Were they loaded already?
         String propAreLoaded = System.getProperty("PropertiesLoadedFlag");
         if (propAreLoaded != null) {
@@ -307,11 +306,9 @@ public class HelperMisc {
 
             System.setProperties(sysProps);
             System.setProperty("PropertiesLoadedFlag", "true");
-
         } catch (MalformedURLException ex) {
             Logger.getLogger(HelperMisc.class.getName()).log(Level.SEVERE, null, ex);
         }
-
     }
 
     /**

--- a/apis/api-area002-v001-com/pom.xml
+++ b/apis/api-area002-v001-com/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area002-v001-com</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - COM v001</name>

--- a/apis/api-area002-v001-com/pom.xml
+++ b/apis/api-area002-v001-com/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area002-v001-com</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - COM v001</name>

--- a/apis/api-area003-v001-common/pom.xml
+++ b/apis/api-area003-v001-common/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area003-v001-common</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - Common  v001</name>

--- a/apis/api-area003-v001-common/pom.xml
+++ b/apis/api-area003-v001-common/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area003-v001-common</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - Common  v001</name>

--- a/apis/api-area004-v001-mc/pom.xml
+++ b/apis/api-area004-v001-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area004-v001-mc</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MC v001</name>

--- a/apis/api-area004-v001-mc/pom.xml
+++ b/apis/api-area004-v001-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area004-v001-mc</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MC v001</name>

--- a/apis/api-area004-v002-mc/pom.xml
+++ b/apis/api-area004-v002-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area004-v002-mc</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MC v002</name>

--- a/apis/api-area004-v002-mc/pom.xml
+++ b/apis/api-area004-v002-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area004-v002-mc</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MC v002</name>

--- a/apis/api-area005-v001-mps/pom.xml
+++ b/apis/api-area005-v001-mps/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area005-v001-mps</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MPS v001</name>

--- a/apis/api-area005-v001-mps/pom.xml
+++ b/apis/api-area005-v001-mps/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area005-v001-mps</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MPS v001</name>

--- a/apis/api-area009-v001-mpd/pom.xml
+++ b/apis/api-area009-v001-mpd/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area009-v001-mpd</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MPD v001</name>

--- a/apis/api-area009-v001-mpd/pom.xml
+++ b/apis/api-area009-v001-mpd/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-area009-v001-mpd</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO API - MPD v001</name>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>apis</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA MO APIs</name>
 

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>apis</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA MO APIs</name>
 

--- a/encodings/encoding-binary/pom.xml
+++ b/encodings/encoding-binary/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encoding-binary</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Encoder - Binary</name>
     <description>A simple Java binary encoder for the CCSDS MAL</description>

--- a/encodings/encoding-binary/pom.xml
+++ b/encodings/encoding-binary/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encoding-binary</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Encoder - Binary</name>
     <description>A simple Java binary encoder for the CCSDS MAL</description>

--- a/encodings/encoding-string/pom.xml
+++ b/encodings/encoding-string/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encoding-string</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Encoder - String</name>
     <description>A simple Java String based encoder for the CCSDS MAL</description>

--- a/encodings/encoding-string/pom.xml
+++ b/encodings/encoding-string/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encoding-string</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Encoder - String</name>
     <description>A simple Java String based encoder for the CCSDS MAL</description>

--- a/encodings/encoding-xml/pom.xml
+++ b/encodings/encoding-xml/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encoding-xml</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Encoder - XML</name>
     <description>A simple Java String based encoder for the CCSDS MAL</description>

--- a/encodings/encoding-xml/pom.xml
+++ b/encodings/encoding-xml/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encoding-xml</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Encoder - XML</name>
     <description>A simple Java String based encoder for the CCSDS MAL</description>

--- a/encodings/pom.xml
+++ b/encodings/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encodings</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA MO Encodings</name>
 

--- a/encodings/pom.xml
+++ b/encodings/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>encodings</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA MO Encodings</name>
 

--- a/mal-impl/pom.xml
+++ b/mal-impl/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>mal-impl</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO MAL Java Implementation</name>
     <description>The ESA implementation of the CCSDS MAL in Java</description>

--- a/mal-impl/pom.xml
+++ b/mal-impl/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>mal-impl</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO MAL Java Implementation</name>
     <description>The ESA implementation of the CCSDS MAL in Java</description>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>parent</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
   
     <name>ESA MO POM</name>
@@ -73,7 +73,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <esa.mo.version>14.1-SNAPSHOT</esa.mo.version>
+        <esa.mo.version>14.1</esa.mo.version>
         <ccsds.specification.version>${esa.mo.version}</ccsds.specification.version>
         <extra.specification.version>${esa.mo.version}</extra.specification.version>
     

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>parent</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
   
     <name>ESA MO POM</name>
@@ -73,7 +73,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <esa.mo.version>14.0</esa.mo.version>
+        <esa.mo.version>14.1-SNAPSHOT</esa.mo.version>
         <ccsds.specification.version>${esa.mo.version}</ccsds.specification.version>
         <extra.specification.version>${esa.mo.version}</extra.specification.version>
     

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
   

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
   

--- a/services-impl/pom.xml
+++ b/services-impl/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-impl</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA MO Services Implementations</name>
 

--- a/services-impl/pom.xml
+++ b/services-impl/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-impl</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA MO Services Implementations</name>
 

--- a/services-impl/services-area003-v001-common/pom.xml
+++ b/services-impl/services-area003-v001-common/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-area003-v001-common</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Services - Common Services</name>

--- a/services-impl/services-area003-v001-common/pom.xml
+++ b/services-impl/services-area003-v001-common/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-area003-v001-common</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Services - Common Services</name>

--- a/services-impl/services-area004-v002-mc/pom.xml
+++ b/services-impl/services-area004-v002-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-area004-v002-mc</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Services - MC Services</name>

--- a/services-impl/services-area004-v002-mc/pom.xml
+++ b/services-impl/services-area004-v002-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-area004-v002-mc</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Services - MC Services</name>

--- a/services-impl/services-area009-v001-mpd/pom.xml
+++ b/services-impl/services-area009-v001-mpd/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-area009-v001-mpd</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Services - MPD Services</name>

--- a/services-impl/services-area009-v001-mpd/pom.xml
+++ b/services-impl/services-area009-v001-mpd/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>services-area009-v001-mpd</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Services - MPD Services</name>

--- a/testbeds/pom.xml
+++ b/testbeds/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbeds</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA CCSDS Testbed reactor build</name>
 

--- a/testbeds/pom.xml
+++ b/testbeds/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbeds</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA CCSDS Testbed reactor build</name>
 

--- a/testbeds/test-apis/pom.xml
+++ b/testbeds/test-apis/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>test-apis</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>CCSDS MOIMS MO Testbed APIs</name>
 

--- a/testbeds/test-apis/pom.xml
+++ b/testbeds/test-apis/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>test-apis</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CCSDS MOIMS MO Testbed APIs</name>
 

--- a/testbeds/test-apis/test-api-com/pom.xml
+++ b/testbeds/test-apis/test-api-com/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-com-test</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed API - COM</name>

--- a/testbeds/test-apis/test-api-com/pom.xml
+++ b/testbeds/test-apis/test-api-com/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-com-test</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed API - COM</name>

--- a/testbeds/test-apis/test-api-mal/pom.xml
+++ b/testbeds/test-apis/test-api-mal/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>api-mal-test</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed API - MAL</name>

--- a/testbeds/test-apis/test-api-mal/pom.xml
+++ b/testbeds/test-apis/test-api-mal/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>api-mal-test</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed API - MAL</name>

--- a/testbeds/test-apis/test-api-mc/pom.xml
+++ b/testbeds/test-apis/test-api-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-mc-test</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed API - MC</name>

--- a/testbeds/test-apis/test-api-mc/pom.xml
+++ b/testbeds/test-apis/test-api-mc/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
 
     <artifactId>api-mc-test</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed API - MC</name>

--- a/testbeds/testbed-com-framework/pom.xml
+++ b/testbeds/testbed-com-framework/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-com-framework</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed COM - Harness</name>
   
     <organization>

--- a/testbeds/testbed-com-framework/pom.xml
+++ b/testbeds/testbed-com-framework/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-com-framework</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed COM - Harness</name>
   
     <organization>

--- a/testbeds/testbed-com-provider-esa/pom.xml
+++ b/testbeds/testbed-com-provider-esa/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-com-provider-esa</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
   
     <name>CCSDS MOIMS MO Testbed COM - Provider Impl</name>

--- a/testbeds/testbed-com-provider-esa/pom.xml
+++ b/testbeds/testbed-com-provider-esa/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-com-provider-esa</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
   
     <name>CCSDS MOIMS MO Testbed COM - Provider Impl</name>

--- a/testbeds/testbed-com/pom.xml
+++ b/testbeds/testbed-com/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-com</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed for COM</name>
 
     <organization>

--- a/testbeds/testbed-com/pom.xml
+++ b/testbeds/testbed-com/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-com</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed for COM</name>
 
     <organization>

--- a/testbeds/testbed-encoders/pom.xml
+++ b/testbeds/testbed-encoders/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-encoders</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed Encoders</name>
 
     <organization>

--- a/testbeds/testbed-encoders/pom.xml
+++ b/testbeds/testbed-encoders/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-encoders</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed Encoders</name>
 
     <organization>

--- a/testbeds/testbed-mal/pom.xml
+++ b/testbeds/testbed-mal/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-mal</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed for MAL</name>
 
     <organization>

--- a/testbeds/testbed-mal/pom.xml
+++ b/testbeds/testbed-mal/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-mal</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed for MAL</name>
 
     <organization>

--- a/testbeds/testbed-malspp-framework/pom.xml
+++ b/testbeds/testbed-malspp-framework/pom.xml
@@ -40,14 +40,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-malspp-framework</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed Framework for MAL/SPP Binding </name>
 
     <organization>

--- a/testbeds/testbed-malspp-framework/pom.xml
+++ b/testbeds/testbed-malspp-framework/pom.xml
@@ -40,14 +40,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-malspp-framework</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed Framework for MAL/SPP Binding </name>
 
     <organization>

--- a/testbeds/testbed-malspp/pom.xml
+++ b/testbeds/testbed-malspp/pom.xml
@@ -40,14 +40,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-malspp</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed for MAL/SPP Binding</name>
 
     <organization>

--- a/testbeds/testbed-malspp/pom.xml
+++ b/testbeds/testbed-malspp/pom.xml
@@ -40,14 +40,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-malspp</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed for MAL/SPP Binding</name>
 
     <organization>

--- a/testbeds/testbed-mc/pom.xml
+++ b/testbeds/testbed-mc/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-mc</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed MC</name>
 
     <organization>

--- a/testbeds/testbed-mc/pom.xml
+++ b/testbeds/testbed-mc/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-mc</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed MC</name>
 
     <organization>

--- a/testbeds/testbed-mpd/pom.xml
+++ b/testbeds/testbed-mpd/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-mpd</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed MPD</name>
 
     <organization>

--- a/testbeds/testbed-mpd/pom.xml
+++ b/testbeds/testbed-mpd/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-mpd</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed MPD</name>
 
     <organization>

--- a/testbeds/testbed-pom/pom.xml
+++ b/testbeds/testbed-pom/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-pom</artifactId>
     <packaging>pom</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed POM</name>
 
     <organization>

--- a/testbeds/testbed-pom/pom.xml
+++ b/testbeds/testbed-pom/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-pom</artifactId>
     <packaging>pom</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed POM</name>
 
     <organization>

--- a/testbeds/testbed-util-spp/pom.xml
+++ b/testbeds/testbed-util-spp/pom.xml
@@ -40,14 +40,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-util-spp</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed utilities for the Space Packet Protocol</name>
 
     <organization>

--- a/testbeds/testbed-util-spp/pom.xml
+++ b/testbeds/testbed-util-spp/pom.xml
@@ -40,14 +40,14 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>testbed-util-spp</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed utilities for the Space Packet Protocol</name>
 
     <organization>

--- a/testbeds/testbed-util/pom.xml
+++ b/testbeds/testbed-util/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-util</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <name>CCSDS MOIMS MO Testbed utilities</name>
 
     <organization>

--- a/testbeds/testbed-util/pom.xml
+++ b/testbeds/testbed-util/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>testbed-pom</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../testbed-pom/pom.xml</relativePath>
     </parent>
   
     <artifactId>testbed-util</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <name>CCSDS MOIMS MO Testbed utilities</name>
 
     <organization>

--- a/testbeds/xml-tests/pom.xml
+++ b/testbeds/xml-tests/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-tests</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed XML</name>

--- a/testbeds/xml-tests/pom.xml
+++ b/testbeds/xml-tests/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-tests</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CCSDS MOIMS MO Testbed XML</name>

--- a/tooling/basic-demo/pom.xml
+++ b/tooling/basic-demo/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>basic-demo</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Java Demo</name>
     <description>A Demo Java application for the CCSDS MAL</description>

--- a/tooling/basic-demo/pom.xml
+++ b/tooling/basic-demo/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>basic-demo</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Java Demo</name>
     <description>A Demo Java application for the CCSDS MAL</description>

--- a/tooling/mo-navigator/pom.xml
+++ b/tooling/mo-navigator/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>mo-navigator</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <name>ESA MO Navigator</name>

--- a/tooling/mo-navigator/pom.xml
+++ b/tooling/mo-navigator/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>mo-navigator</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
     
     <name>ESA MO Navigator</name>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>tooling</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA MO Tooling</name>
 

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>tooling</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA MO Tooling</name>
 

--- a/tooling/simple-mo-consumer/pom.xml
+++ b/tooling/simple-mo-consumer/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>simple-mo-consumer</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
     
     <name>Simple MO Consumer</name>

--- a/tooling/simple-mo-consumer/pom.xml
+++ b/tooling/simple-mo-consumer/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>simple-mo-consumer</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <name>Simple MO Consumer</name>

--- a/tooling/simple-mo-provider/pom.xml
+++ b/tooling/simple-mo-provider/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>simple-mo-provider</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
     
     <name>Simple MO Provider</name>

--- a/tooling/simple-mo-provider/pom.xml
+++ b/tooling/simple-mo-provider/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>simple-mo-provider</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <name>Simple MO Provider</name>

--- a/tooling/transport-bridge/pom.xml
+++ b/tooling/transport-bridge/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-bridge</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Transport Bridge</name>

--- a/tooling/transport-bridge/pom.xml
+++ b/tooling/transport-bridge/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-bridge</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Transport Bridge</name>

--- a/transports/pom.xml
+++ b/transports/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transports</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA MO Transports</name>
 

--- a/transports/pom.xml
+++ b/transports/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transports</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA MO Transports</name>
 

--- a/transports/transport-file/pom.xml
+++ b/transports/transport-file/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-file</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Transport - File</name>
     <description>A Java File based transport for CCSDS MAL</description>

--- a/transports/transport-file/pom.xml
+++ b/transports/transport-file/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-file</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Transport - File</name>
     <description>A Java File based transport for CCSDS MAL</description>

--- a/transports/transport-generic/pom.xml
+++ b/transports/transport-generic/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-generic</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Transport - Generic Framework</name>
     <description>A base Java framework for CCSDS MAL transports</description>

--- a/transports/transport-generic/pom.xml
+++ b/transports/transport-generic/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-generic</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Transport - Generic Framework</name>
     <description>A base Java framework for CCSDS MAL transports</description>

--- a/transports/transport-generic/src/main/java/esa/mo/mal/transport/gen/body/LazyMessageBody.java
+++ b/transports/transport-generic/src/main/java/esa/mo/mal/transport/gen/body/LazyMessageBody.java
@@ -228,12 +228,21 @@ public class LazyMessageBody implements MALMessageBody, java.io.Serializable {
     }
 
     /**
-     * Decodes the message body.
+     * Decodes the message body. Synchronized because the same body can be
+     * decoded from two threads: the thread of a synchronous consumer call
+     * unblocked by the interaction handler, and the message dispatcher thread
+     * delivering the same message to the interaction listener.
      *
      * @throws MALException if any error detected.
      */
-    protected void decodeMessageBody() throws MALException {
+    protected synchronized void decodeMessageBody() throws MALException {
         if (decodedBody) {
+            if (messageParts == null) {
+                // A previous decode attempt failed; fail loudly instead of
+                // letting the callers trip over the null messageParts
+                throw new MALException("The Message Body could not be decoded "
+                        + "by a previous decoding attempt!");
+            }
             return;
         }
 
@@ -274,6 +283,10 @@ public class LazyMessageBody implements MALMessageBody, java.io.Serializable {
         } catch (NotFoundException ex) {
             Transport.LOGGER.log(Level.WARNING,
                     "(2) Unable to decode the Message Body!", ex);
+            // Propagate instead of swallowing: otherwise messageParts stays
+            // null and readers fail later with an NPE that hides this cause
+            throw new MALException("Unable to decode the Message Body! "
+                    + "The operation could not be found!", ex);
         }
     }
 

--- a/transports/transport-generic/src/main/java/esa/mo/mal/transport/gen/body/LazyMessageBody.java
+++ b/transports/transport-generic/src/main/java/esa/mo/mal/transport/gen/body/LazyMessageBody.java
@@ -92,7 +92,11 @@ public class LazyMessageBody implements MALMessageBody, java.io.Serializable {
             final Object[] messageParts) {
         this.ctx = ctx;
         this.bodyPartCount = (messageParts != null) ? messageParts.length : 0;
-        this.messageParts = messageParts;
+        // Never leave messageParts null while decodedBody is true: an empty body
+        // (e.g. a request with no arguments) is passed as null, and the repeated-
+        // read guard in decodeMessageBody() would otherwise report it as a failed
+        // decode. An empty array encodes as a zero-part body.
+        this.messageParts = (messageParts != null) ? messageParts : new Object[0];
         this.encFactory = encFactory;
         decodedBody = true;
     }
@@ -283,6 +287,15 @@ public class LazyMessageBody implements MALMessageBody, java.io.Serializable {
         } catch (NotFoundException ex) {
             Transport.LOGGER.log(Level.WARNING,
                     "(2) Unable to decode the Message Body!", ex);
+            // The operation fields are unknown, so the body structure cannot be
+            // recovered. Degrade to an empty body (the historical log-and-continue
+            // behavior) instead of leaving messageParts null: otherwise the
+            // repeated-read guard above would later report this tolerated path as
+            // a SEVERE encoding error.
+            if (messageParts == null) {
+                bodyPartCount = 0;
+                messageParts = new Element[0];
+            }
         }
     }
 

--- a/transports/transport-generic/src/main/java/esa/mo/mal/transport/gen/body/LazyMessageBody.java
+++ b/transports/transport-generic/src/main/java/esa/mo/mal/transport/gen/body/LazyMessageBody.java
@@ -283,10 +283,6 @@ public class LazyMessageBody implements MALMessageBody, java.io.Serializable {
         } catch (NotFoundException ex) {
             Transport.LOGGER.log(Level.WARNING,
                     "(2) Unable to decode the Message Body!", ex);
-            // Propagate instead of swallowing: otherwise messageParts stays
-            // null and readers fail later with an NPE that hides this cause
-            throw new MALException("Unable to decode the Message Body! "
-                    + "The operation could not be found!", ex);
         }
     }
 

--- a/transports/transport-http/pom.xml
+++ b/transports/transport-http/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>transport-http</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Transport - HTTP</name>
     <description>A Java HTTP transport for CCSDS MAL</description>

--- a/transports/transport-http/pom.xml
+++ b/transports/transport-http/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>transport-http</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Transport - HTTP</name>
     <description>A Java HTTP transport for CCSDS MAL</description>

--- a/transports/transport-rmi/pom.xml
+++ b/transports/transport-rmi/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-rmi</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Transport - RMI</name>
     <description>A Java RMI transport for CCSDS MAL</description>

--- a/transports/transport-rmi/pom.xml
+++ b/transports/transport-rmi/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-rmi</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Transport - RMI</name>
     <description>A Java RMI transport for CCSDS MAL</description>

--- a/transports/transport-spp/pom.xml
+++ b/transports/transport-spp/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-spp</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Transport - SPP</name>
     <description>A Java SPP transport for CCSDS MAL</description>

--- a/transports/transport-spp/pom.xml
+++ b/transports/transport-spp/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-spp</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Transport - SPP</name>
     <description>A Java SPP transport for CCSDS MAL</description>

--- a/transports/transport-tcpip/pom.xml
+++ b/transports/transport-tcpip/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-tcpip</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Transport - TCP/IP</name>

--- a/transports/transport-tcpip/pom.xml
+++ b/transports/transport-tcpip/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
   
     <artifactId>transport-tcpip</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO Transport - TCP/IP</name>

--- a/transports/transport-zmtp/pom.xml
+++ b/transports/transport-zmtp/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>transport-zmtp</artifactId>
     <packaging>jar</packaging>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
 
     <name>ESA MO Transport - ZMTP</name>
     <description>A Java ZeroMQ Transport Protocol binding for CCSDS MAL</description>

--- a/transports/transport-zmtp/pom.xml
+++ b/transports/transport-zmtp/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>transport-zmtp</artifactId>
     <packaging>jar</packaging>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
 
     <name>ESA MO Transport - ZMTP</name>
     <description>A Java ZeroMQ Transport Protocol binding for CCSDS MAL</description>

--- a/xml-service-specifications/pom.xml
+++ b/xml-service-specifications/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-service-specifications</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>pom</packaging>
     <name>ESA MO XML specifications</name>
 

--- a/xml-service-specifications/pom.xml
+++ b/xml-service-specifications/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-service-specifications</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ESA MO XML specifications</name>
 

--- a/xml-service-specifications/xml-ccsds-mo-prototypes/pom.xml
+++ b/xml-service-specifications/xml-ccsds-mo-prototypes/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-ccsds-mo-prototypes</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
   
     <name>ESA MO XML specifications - MO Prototypes</name>

--- a/xml-service-specifications/xml-ccsds-mo-prototypes/pom.xml
+++ b/xml-service-specifications/xml-ccsds-mo-prototypes/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-ccsds-mo-prototypes</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
   
     <name>ESA MO XML specifications - MO Prototypes</name>

--- a/xml-service-specifications/xml-ccsds-mo-standards/pom.xml
+++ b/xml-service-specifications/xml-ccsds-mo-standards/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.0</version>
+        <version>14.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-ccsds-mo-standards</artifactId>
-    <version>14.0</version>
+    <version>14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ESA MO XML specifications - MO Standards</name>

--- a/xml-service-specifications/xml-ccsds-mo-standards/pom.xml
+++ b/xml-service-specifications/xml-ccsds-mo-standards/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>int.esa.ccsds.mo</groupId>
         <artifactId>parent</artifactId>
-        <version>14.1-SNAPSHOT</version>
+        <version>14.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>int.esa.ccsds.mo</groupId>
     <artifactId>xml-ccsds-mo-standards</artifactId>
-    <version>14.1-SNAPSHOT</version>
+    <version>14.1</version>
     <packaging>jar</packaging>
 
     <name>ESA MO XML specifications - MO Standards</name>


### PR DESCRIPTION
Release of version 14.1.

### Changes since 14.0
* Vendors the W3C XML Schema files instead of downloading them at build time (removes the build's dependency on network access to w3.org)
* Fixes a race condition and silent failures in the LazyMessageBody decoding
* Restores the log-and-continue handling of NotFoundException during decoding
* No longer reports empty message bodies as failed decodes
* Loads the consumer.properties file only once per JVM

To be **Squash and Merged**, per RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)